### PR TITLE
bugfix permission error

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,29 +5,44 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  pages: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    env:
+      PYTHON_VERSION: '3.x'
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v2
+      - name: Setup Python
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.x
+          python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Install MkDocs and dependencies
+      - name: Cache Python dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
         run: |
+          python -m pip install --upgrade pip
           pip install mkdocs mkdocs-material
 
-      - name: Build MkDocs site
-        run: |
-          mkdocs build
+      - name: Build documentation
+        run: mkdocs build
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./site
+          force_orphan: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   mkdocs:
     build: .


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow and a minor change to the Docker Compose configuration. The most important changes focus on improving the deployment process and updating dependencies.

### Workflow improvements:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R8-R48): Added `permissions` for `contents` and `pages` to write, set up environment variables for Python version, updated `actions/checkout` and `actions/setup-python` to version 4, added caching for Python dependencies, and streamlined the installation and build steps.

### Configuration update:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L1-L2): Removed the version specification from the Docker Compose file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated deployment workflow for MkDocs to enhance permissions and environment setup.
	- Added caching for Python dependencies to streamline the build process.
	- Simplified documentation build and installation steps.

- **Refactor**
	- Removed version declaration from `docker-compose.yml`, allowing default to the latest Docker Compose format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->